### PR TITLE
Add displayName parameter to Document initialization and update KeyChainStorageService

### DIFF
--- a/Sources/WalletStorage/Document.swift
+++ b/Sources/WalletStorage/Document.swift
@@ -19,7 +19,7 @@ import MdocDataModel18013
 
 /// wallet document structure
 public struct Document: Sendable {
-	public init(id: String = UUID().uuidString, docType: String?, docDataFormat: DocDataFormat, data: Data, secureAreaName: String?, createdAt: Date?, modifiedAt: Date? = nil, metadata: Data?, status: DocumentStatus) {
+	public init(id: String = UUID().uuidString, docType: String?, docDataFormat: DocDataFormat, data: Data, secureAreaName: String?, createdAt: Date?, modifiedAt: Date? = nil, metadata: Data?, displayName: String?, status: DocumentStatus) {
 		self.id = id
 		self.docType = docType
 		self.docDataFormat = docDataFormat
@@ -28,6 +28,7 @@ public struct Document: Sendable {
 		self.createdAt = createdAt ?? Date()
 		self.modifiedAt = modifiedAt
 		self.metadata = metadata
+		self.displayName = displayName
 		self.status = status
 	}
 	
@@ -39,9 +40,12 @@ public struct Document: Sendable {
 	public let createdAt: Date
 	public let modifiedAt: Date?
 	public let metadata: Data?
+	public var displayName: String?	
 	public let status: DocumentStatus
 	public var statusDescription: String? {	status.rawValue	}
 	public var isDeferred: Bool { status == .deferred }
+
+	
 	
 	public func getDataForTransfer() -> (doc: (String, Data), fmt: (String, String), sa: (String, String))? {
 		guard let sa = secureAreaName else { return nil }

--- a/Sources/WalletStorage/KeyChainStorageService.swift
+++ b/Sources/WalletStorage/KeyChainStorageService.swift
@@ -165,6 +165,6 @@ public actor KeyChainStorageService: DataStorageService  {
 		defer { let c = data.count; data.withUnsafeMutableBytes { memset_s($0.baseAddress, c, 0, c); return } }
 		let descrBase64 =  dict[kSecAttrDescription as String] as? String
 		let md: Data? = if let descrBase64 { Data(base64Encoded: descrBase64) } else { nil }
-		return Document(id: dict[kSecAttrAccount as String] as! String, docType: dict[kSecAttrLabel as String] as? String, docDataFormat: DocDataFormat(rawValue: dict[kSecAttrType as String] as? String ?? DocDataFormat.cbor.rawValue) ?? DocDataFormat.cbor, data: data, secureAreaName: dict[kSecAttrComment as String] as? String, createdAt: (dict[kSecAttrCreationDate as String] as! Date), modifiedAt: dict[kSecAttrModificationDate as String] as? Date, metadata: md, status: status)
+		return Document(id: dict[kSecAttrAccount as String] as! String, docType: dict[kSecAttrLabel as String] as? String, docDataFormat: DocDataFormat(rawValue: dict[kSecAttrType as String] as? String ?? DocDataFormat.cbor.rawValue) ?? DocDataFormat.cbor, data: data, secureAreaName: dict[kSecAttrComment as String] as? String, createdAt: (dict[kSecAttrCreationDate as String] as! Date), modifiedAt: dict[kSecAttrModificationDate as String] as? Date, metadata: md, displayName: nil, status: status)
 	}
 }


### PR DESCRIPTION
Introduce a `displayName` parameter to the `Document` struct for enhanced initialization flexibility. Update the `KeyChainStorageService` to accommodate this change.