### PR TITLE
Bump eudi-lib-ios-iso18013-data-model to version 0.5.7

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "1eaef66185a4e18b0030cf383404d5a5305c3057cfe245a78d6ca525d8b45433",
+  "originHash" : "61bfb21db0ab5422796684d4b1706fe6d5fec07856ab2370e05f2d5c6fb07d4a",
   "pins" : [
     {
       "identity" : "eudi-lib-ios-iso18013-data-model",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-model.git",
       "state" : {
-        "revision" : "dc3d6f457d22cd5275a42c562d38eb2dc5b01042",
-        "version" : "0.5.6"
+        "revision" : "a3b965598ea9d6200bc3a2762862ccd65ba2e648",
+        "version" : "0.5.7"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.3"),
-		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-model.git", exact: "0.5.6"),
+		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-model.git", exact: "0.5.7"),
 		],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.


### PR DESCRIPTION
Update the dependency version for eudi-lib-ios-iso18013-data-model to 0.5.7 to incorporate the latest changes.