### PR TITLE
Update supported platform versions and enhance data transfer method

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "WalletStorage",
     defaultLocalization: "en",
-	platforms: [.macOS(.v12), .iOS(.v15), .watchOS(.v9)],
+	platforms: [.macOS(.v13), .iOS(.v16), .watchOS(.v10)],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.
         .library( 

--- a/Sources/WalletStorage/Document.swift
+++ b/Sources/WalletStorage/Document.swift
@@ -45,10 +45,10 @@ public struct Document: Sendable {
 	public var statusDescription: String? {	status.rawValue	}
 	public var isDeferred: Bool { status == .deferred }
 	
-	// get pairs: (doc, fmt, sa)
-	public func getDataForTransfer() -> (doc: (String, Data), fmt: (String, String), sa: (String, String))? {
+	// get pairs: (doc, metadata, fmt, sa)
+	public func getDataForTransfer() -> (doc: (String, Data), metadata: (String, Data?), fmt: (String, String), sa: (String, String))? {
 		guard let sa = secureAreaName else { return nil }
-		return ((id, data), (id, docDataFormat.rawValue), (id, sa))
+		return ((id, data), (id, metadata), (id, docDataFormat.rawValue), (id, sa))
 	}
 
 }


### PR DESCRIPTION
Update the minimum supported versions for macOS, iOS, and watchOS. Modify the data transfer method to include metadata in the returned tuple.