### PR TITLE
fix: store keychain items with ThisDeviceOnly accessibility

### DIFF
--- a/Sources/WalletStorage/KeyChainSecureKeyStorage.swift
+++ b/Sources/WalletStorage/KeyChainSecureKeyStorage.swift
@@ -65,13 +65,14 @@ public actor KeyChainSecureKeyStorage: SecureKeyStorage {
 	func setDictValues1(_ d: inout [String: Any]) {
 		guard let dict else { return }
 		for (k, v) in dict { d[k] = if k == kSecValueData as String { v } else { String(data: v, encoding: .utf8) ?? "" } }
+		d[kSecAttrAccessible as String] = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
 	}
 	
 	// helper function to convert generic data dictionary to keychain expected dictionary, create access control value if needed
 	func setDictValues2(_ d: inout [String: Any]) {
 		guard let dict else { return }
 		for (k, v) in dict { d[k] = if k == kSecValueData as String { v } else { String(data: v, encoding: .utf8) ?? "" } }
-		d[kSecAttrAccessControl as String] = SecAccessControlCreateWithFlags(nil, keyOptions?.accessProtection?.constant ?? kSecAttrAccessibleWhenUnlocked, keyOptions?.accessControl?.flags ?? [], nil)! as Any
+		d[kSecAttrAccessControl as String] = SecAccessControlCreateWithFlags(nil, keyOptions?.accessProtection?.constant ?? kSecAttrAccessibleWhenUnlockedThisDeviceOnly, keyOptions?.accessControl?.flags ?? [], nil)! as Any
 	}
 
 }

--- a/Sources/WalletStorage/KeyChainStorageService.swift
+++ b/Sources/WalletStorage/KeyChainStorageService.swift
@@ -120,6 +120,7 @@ public actor KeyChainStorageService: DataStorageService  {
 		if let md = documentToSave.metadata { d[kSecAttrDescription as String] = md.base64EncodedString() }
 		if let dki = documentToSave.docKeyInfo { d[kSecAttrComment as String] = dki.base64EncodedString() }
 		d[kSecAttrType as String] = documentToSave.docDataFormat.rawValue
+		d[kSecAttrAccessible as String] = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
 	}
 	
 	/// Make a query for a an item in keychain


### PR DESCRIPTION
## Summary
Use a device-bound accessibility class for keychain items stored by `wallet-storage` so they are not migrated via backups.

## Motivation
This change reduces exposure of sensitive stored values by keeping them bound to the current device.

## Testing
Manual verification in an app integration using encrypted iTunes backup inspection:
- before the change, the affected generic password entries were present in the backup
- after the change, those entries were no longer present
