### PR TITLE
Update default access control flags to include user presence

### DIFF
--- a/Sources/WalletStorage/KeyChainSecureKeyStorage.swift
+++ b/Sources/WalletStorage/KeyChainSecureKeyStorage.swift
@@ -150,7 +150,7 @@ public actor KeyChainSecureKeyStorage: SecureKeyStorage {
 		}
 		let accessProtection =
 			keyOptions?.accessProtection?.constant ?? kSecAttrAccessibleWhenUnlockedThisDeviceOnly
-		let accessControlFlags = keyOptions?.accessControl?.flags ?? []
+		let accessControlFlags = keyOptions?.accessControl?.flags ?? [.userPresence]
 		let accessControl = SecAccessControlCreateWithFlags(nil, accessProtection, accessControlFlags, nil)!
 		d[kSecAttrAccessControl as String] = accessControl as Any
 	}


### PR DESCRIPTION
Modify the default access control flags to ensure user presence is included, enhancing security measures.